### PR TITLE
Correctly check if a user/group doesn't exist

### DIFF
--- a/app/classes/RadEntityMapper.php
+++ b/app/classes/RadEntityMapper.php
@@ -58,6 +58,8 @@ abstract class RadEntityMapper {
 			$radentity->replyattrs = $this->retrieveAttrs($rtn, $name);
 
 			return $radentity;
+		} else {
+			throw new Exception;
 		}
 	}
 

--- a/app/pages/groups_edit.php
+++ b/app/pages/groups_edit.php
@@ -57,11 +57,11 @@ if($_SERVER['REQUEST_METHOD'] == "POST") {
 		die("No group specified.");
 	}
 
-	// Get user
 	$groupmapper = new GroupMapper($fr_db);
-	$group = $groupmapper->getByName($_GET['name']);
-
-	if(empty($group)) {
+	// Get group
+	try {
+		$group = $groupmapper->getByName($_GET['name']);
+	} catch (Exception $e) {
 		die("Non-existent group specified.");
 	}
 

--- a/app/pages/users_edit.php
+++ b/app/pages/users_edit.php
@@ -57,11 +57,11 @@ if($_SERVER['REQUEST_METHOD'] == "POST") {
 		die("No user specified.");
 	}
 
-	// Get user
 	$usermapper = new UserMapper($fr_db);
-	$user = $usermapper->getByName($_GET['name']);
-
-	if(empty($user)) {
+	// Get user
+	try {
+		$user = $usermapper->getByName($_GET['name']);
+	} catch (Exception $e) {
 		die("Non-existent user specified.");
 	}
 


### PR DESCRIPTION
Requesting data of a non-existent user/group resulted in a PHP error: "Return value of RadEntityMapper::getByName() must be an instance of RadEntity, none returned".